### PR TITLE
maint(ci): run benchmarks in GitHub Actions

### DIFF
--- a/.github/workflows/comment-on-pr.yml
+++ b/.github/workflows/comment-on-pr.yml
@@ -1,0 +1,82 @@
+# ------------------------------------------------------------------ #
+#                                                                    #
+#           SymPy CI script to comment on a PR                       #
+#                                                                    #
+#   Runs after the main tests are complete and reports results.      #
+#                                                                    #
+# ------------------------------------------------------------------ #
+
+on:
+  workflow_run:
+    # test is the name given for the workflow in runtests.yml
+    workflows: ["test"]
+    types: [completed]
+
+jobs:
+
+  comment-on-pr:
+    runs-on: ubuntu-latest
+    # Only run if the tests passed:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+        # Need a special plugin to retrieve an artifact from another workflow.
+      - name: Download artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{secrets.GITHUB_TOKEN}}
+          workflow: runtests.yml
+          workflow_conclusion: success
+          name: benchmarks
+
+        # The previous workflow stored the issue number for the PR. We need it
+        # here to be able to comment on the PR
+
+      - name: Read the pr_num file
+        id: pr_num_reader
+        uses: juliangruber/read-file-action@v1.0.0
+        with:
+          path: pr_num.txt
+
+      - name: Read the benchmark output
+        id: pr_vs_master_changed
+        uses: juliangruber/read-file-action@v1.0.0
+        with:
+          path: pr_vs_master_changed.txt
+
+      - name: Read the benchmark output
+        id: master_vs_release_changed
+        uses: juliangruber/read-file-action@v1.0.0
+        with:
+          path: master_vs_release_changed.txt
+
+        # The two steps below should create a new comment or update the
+        # existing comment (edit-mode: replace). Note that the opening line of
+        # the comment body is matched by body-includes so if that does not
+        # match then a new comment will always be created.
+
+      - name: Find Comment
+        # This may be running after a push with no associated PR in which case
+        # the PR number variable is empty. Skip commenting in that case.
+        if: ${{ steps.pr_num_reader.outputs.content != '' }}
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+          issue-number: ${{ steps.pr_num_reader.outputs.content }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Benchmark results from GitHub Actions
+
+      - name: Create or update comment
+        if: ${{ steps.pr_num_reader.outputs.content != '' }}
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ steps.pr_num_reader.outputs.content }}
+          body: |
+            Benchmark results from GitHub Actions
+            Ratio less than 1 means a speed up, greater than 1 is a slowdown.
+            Changed benchmark results (PR vs master)
+            ${{ steps.pr_vs_master_changed.outputs.content }}
+            Changed benchmark results (master vs previous release)
+            ${{ steps.master_vs_release_changed.outputs.content }}
+            Full benchmark results can be found as artifacts in GitHub Actions.
+          edit-mode: replace

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -211,3 +211,63 @@ jobs:
         with:
           python-version: 2.7
       - run: bin/test_py2_import.py
+
+
+  # -------------------- Run benchmarks against master and 1.8 ----- #
+
+  benchmarks:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - run: pip install asv virtualenv
+      - run: git submodule add https://github.com/sympy/sympy_benchmarks.git
+
+        # Need to make sure we can access the branches from the main repo. We
+        # will run benchmarks for the PR, for master and for the previous
+        # release. The version branch names below should be updated once there
+        # has been a newer release of sympy. The list of branches to check is
+        # also specified in asv.conf.actions.json which should be updated as
+        # well.
+
+      - run: git remote add upstream https://github.com/sympy/sympy.git
+      - run: git fetch upstream master
+      - run: git fetch upstream 1.8
+
+      - name: Configure benchmarks
+        run: asv machine --yes --config asv.conf.actions.json
+
+        # This is the slow part:
+      - name: Run benchmarks
+        run: asv run --config asv.conf.actions.json
+
+        # Output benchmark results
+      - run: asv compare upstream/master HEAD --config asv.conf.actions.json --factor 1.5 | tee pr_vs_master.txt
+      - run: asv compare upstream/master HEAD --config asv.conf.actions.json --factor 1.5 --only-changed | tee pr_vs_master_changed.txt
+      - run: asv compare upstream/1.8 upstream/master --config asv.conf.actions.json --factor 1.5 | tee master_vs_release.txt
+      - run: asv compare upstream/1.8 upstream/master --config asv.conf.actions.json --factor 1.5 --only-changed | tee master_vs_release_changed.txt
+
+        # This workflow does not have write permissions for the repository so
+        # we save all outputs as artifacts that can be accessed by the
+        # comment-on-pr workflow which is triggered by workflow_run to run when
+        # this one completes. The comment-on-pr workflow also needs the issue
+        # number of the PR to be able to comment so we output that to a file
+        # and pass it over as an artifact as well.
+
+      - name: Save the PR number in an artifact
+        run: echo -n ${{ github.event.number }} > pr_num.txt
+
+      - name: Upload results as artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: benchmarks
+          path: |
+            pr_vs_master.txt
+            pr_vs_master_changed.txt
+            master_vs_release.txt
+            master_vs_release_changed.txt
+            pr_num.txt

--- a/.github/workflows/runtests.yml
+++ b/.github/workflows/runtests.yml
@@ -219,8 +219,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
       - uses: actions/setup-python@v2
         with:
           python-version: 3.8

--- a/asv.conf.actions.json
+++ b/asv.conf.actions.json
@@ -1,0 +1,81 @@
+{
+    // This is the configuration file used for running the benchmarks from
+    // sympy_benchmarks in GitHub Actions. The commands that are run can be
+    // seen in the benchmarks job in runtests.yml.
+
+    // The version of the config file format.  Do not change, unless
+    // you know what you are doing.
+    "version": 1,
+
+    // The name of the project being benchmarked
+    "project": "sympy",
+
+    // The project's homepage
+    "project_url": "http://sympy.org/",
+
+    // The URL or local path of the source code repository for the
+    // project being benchmarked
+    "repo": ".",
+
+    // List of branches to benchmark. If not provided, defaults to "master"
+    // (for git) or "tip" (for mercurial).
+
+    // This list needs to be updated after each release of sympy. The branch to
+    // be checked should always be the previous release.
+    "branches": ["upstream/1.8", "upstream/master", "HEAD"], // for git
+    // "branches": ["tip"],    // for mercurial
+
+    // The DVCS being used.  If not set, it will be automatically
+    // determined from "repo" by looking at the protocol in the URL
+    // (if remote), or by looking for special directories, such as
+    // ".git" (if local).
+    // "dvcs": "git",
+
+    // The tool to use to create environments.  May be "conda",
+    // "virtualenv" or other value depending on the plugins in use.
+    // If missing or the empty string, the tool will be automatically
+    // determined by looking for tools on the PATH environment
+    // variable.
+    "environment_type": "virtualenv",
+
+    // the base URL to show a commit for the project.
+    "show_commit_url": "http://github.com/sympy/sympy/commit/",
+
+    // The Pythons you'd like to test against.  If not provided, defaults
+    // to the current version of Python used to run `asv`.
+    "pythons": ["3.8"],
+
+    // The matrix of dependencies to test.  Each key is the name of a
+    // package (in PyPI) and the values are version numbers.  An empty
+    // list indicates to just test against the default (latest)
+    // version.
+    "matrix": {
+        "mpmath": [],
+        "numpy": []
+    },
+
+    // The directory (relative to the current directory) that benchmarks are
+    // stored in.  If not provided, defaults to "benchmarks"
+    "benchmark_dir": "sympy_benchmarks/benchmarks",
+
+    // The directory (relative to the current directory) to cache the Python
+    // environments in.  If not provided, defaults to "env"
+    "env_dir": "sympy_benchmarks/env",
+
+
+    // The directory (relative to the current directory) that raw benchmark
+    // results are stored in.  If not provided, defaults to "results".
+    "results_dir": "sympy_benchmarks/results"
+
+    // The directory (relative to the current directory) that the html tree
+    // should be written to.  If not provided, defaults to "html".
+    // "html_dir": "html",
+
+    // The number of characters to retain in the commit hashes.
+    // "hash_length": 8,
+
+    // `asv` will cache wheels of the recent builds in each
+    // environment, making them faster to install next time.  This is
+    // number of builds to keep, per environment.
+    // "wheel_cache_size": 0
+}


### PR DESCRIPTION
This commit adds a benchmarks job to run in GitHub Actions for each push
to a PR. Significant benchmark differences will be reported to the PR in
a comment from the GitHub Actions bot.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234" (see
https://tinyurl.com/auto-closing for more information). Also, please
write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments


#### Release Notes

<!-- Write the release notes for this release below between the BEGIN and END
statements. The basic format is a bulleted list with the name of the subpackage
and the release note for this PR. For example:

* solvers
  * Added a new solver for logarithmic equations.

* functions
  * Fixed a bug with log of integers.

or if no release note(s) should be included use:

NO ENTRY

See https://github.com/sympy/sympy/wiki/Writing-Release-Notes for more
information on how to write release notes. The bot will check your release
notes automatically to see if they are formatted correctly. -->

<!-- BEGIN RELEASE NOTES -->

<!-- END RELEASE NOTES -->
